### PR TITLE
REPO-2654: Handle failed delete better

### DIFF
--- a/invenio_users_resources/errors.py
+++ b/invenio_users_resources/errors.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Zenodo-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+"""Group errors."""
+
+
+class ForeignKeyIntegrityError(Exception):
+    """Error for failed requests to delete a group."""

--- a/invenio_users_resources/errors.py
+++ b/invenio_users_resources/errors.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2024 Ubiquity Press.
 #
-# Zenodo-RDM is free software; you can redistribute it and/or modify
+# Invenio-Users-Resources is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 """Group errors."""
 

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from flask import current_app
-from invenio_accounts.models import Domain, Role, User
+from invenio_accounts.models import Domain, User
 from invenio_accounts.proxies import current_datastore
 from invenio_db import db
 from invenio_records.dumpers import SearchDumper, SearchDumperExt
@@ -473,7 +473,7 @@ class GroupAggregate(BaseAggregate):
         return role.users.all()
 
     def delete(self, force=True):
-        """Delete the domain."""
+        """Delete the group."""
         db.session.delete(self.model.model_obj)
 
 

--- a/invenio_users_resources/resources/groups/config.py
+++ b/invenio_users_resources/resources/groups/config.py
@@ -11,10 +11,15 @@
 
 
 import marshmallow as ma
+from flask_resources import HTTPJSONException, create_error_handler
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.resources import (
     RecordResourceConfig,
     SearchRequestArgsSchema,
 )
+from invenio_records_resources.resources.errors import ErrorHandlersMixin
+
+from invenio_users_resources.errors import ForeignKeyIntegrityError
 
 
 #
@@ -40,6 +45,20 @@ class GroupsResourceConfig(RecordResourceConfig):
         "item-avatar": "/<id>/avatar.svg",
         "manage-user": "/<id>/users/<user_id>",
         "users": "/<id>/users",
+    }
+
+    error_handlers = {
+        **ErrorHandlersMixin.error_handlers,
+        ForeignKeyIntegrityError: create_error_handler(
+            lambda e: (
+                HTTPJSONException(
+                    code=403,
+                    description=_(
+                        "You're deleing a group that might be used elsewhere."
+                    ),
+                )
+            )
+        ),
     }
 
     request_view_args = {

--- a/invenio_users_resources/resources/groups/resource.py
+++ b/invenio_users_resources/resources/groups/resource.py
@@ -11,7 +11,7 @@
 
 """User groups resource."""
 
-
+import sqlalchemy
 from flask import g, send_file
 from flask_resources import resource_requestctx, response_handler, route
 from invenio_records_resources.resources import RecordResource
@@ -23,6 +23,8 @@ from invenio_records_resources.resources.records.resource import (
     request_view_args,
 )
 from invenio_records_resources.resources.records.utils import search_preference
+
+from invenio_users_resources.errors import ForeignKeyIntegrityError
 
 
 #
@@ -112,12 +114,15 @@ class GroupsResource(RecordResource):
     @request_headers
     @request_view_args
     def delete(self):
-        """Delete an item."""
-        self.service.delete(
-            g.identity,
-            resource_requestctx.view_args["id"],
-            revision_id=resource_requestctx.headers.get("if_match"),
-        )
+        """Delete a group."""
+        try:
+            self.service.delete(
+                g.identity,
+                resource_requestctx.view_args["id"],
+                revision_id=resource_requestctx.headers.get("if_match"),
+            )
+        except sqlalchemy.exc.IntegrityError as e:
+            raise ForeignKeyIntegrityError(e)
         return "", 204
 
     @request_view_args


### PR DESCRIPTION
Added error handling for when a group is being deleted in admin but cannot be because is associated to a community.